### PR TITLE
Change s3 bucket destination, function name and stack destination

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -53,15 +53,15 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: gdn-cdn
-        S3Key: 2020/11/us-general-election-data/max/notification-lambda.js.v8.zip
+        S3Bucket: mobile-dist
+        S3Key: !Sub ${Stack}/${Stage}/notification-lambda/notification-lambda.zip
       Description: Dispatch notification data from an S3 bucket to the mobile notification system.
       Environment:
         Variables:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub us-election-2020-notification-lambda-${Stage}
       Handler: notification-lambda.handler
       MemorySize: 384
       ReservedConcurrentExecutions: 1

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,4 +1,4 @@
-stacks: [mobile]
+stacks: [mobile-notifications]
 regions: [eu-west-1]
 
 deployments:


### PR DESCRIPTION
## What does this change?
Changes the s3 bucket destination, function name and stack destination so they live in `mobile-notifications`
