### PR TITLE
Integrate cloudwatch alarms to trigger errors

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -91,3 +91,21 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt EventRule.Arn
+
+  LambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
+      AlarmDescription: !Sub Triggers if there are errors persisiting on ${Stage}
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: "Errors"
+      Namespace: "AWS/Lambda"
+      Dimensions:
+        - Name: "FunctionName"
+          Value: !Sub us-election-2020-notification-lambda-${Stage}
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching

--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -100,15 +100,36 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if there are errors persisiting on ${Stage}
-      ComparisonOperator: GreaterThanThreshold
+      AlarmDescription: !Sub Alarm triggers if there is missing notification data, see runbook <<<Runbook|https://docs.google.com/document/d/1JQXFacHrAFB8_7fLthUkIdt1LPYTD99PxJOU_64rY2Y/edit?usp=sharing>>>
+      Metrics:
+        - Id: e1
+          Label: Error percentage of lambda
+          Expression: "100*(m1/m2)"
+        - Id: m1
+          Label: Number of errors for lambda
+          MetricStat:
+            Metric:
+              MetricName: Errors
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub us-election-2020-notification-lambda-${Stage}
+            Period: 600
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          Label: Number of invocations for lambda
+          MetricStat:
+            Metric:
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub us-election-2020-notification-lambda-${Stage}
+            Period: 600
+            Stat: Sum
+          ReturnData: false
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: "Errors"
-      Namespace: "AWS/Lambda"
-      Dimensions:
-        - Name: "FunctionName"
-          Value: !Sub us-election-2020-notification-lambda-${Stage}
-      Period: 3600
-      Statistic: Sum
       Threshold: 1
-      TreatMissingData: breaching
+      TreatMissingData: notBreaching

--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -131,5 +131,5 @@ Resources:
           ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      Threshold: 1
+      Threshold: 100
       TreatMissingData: notBreaching

--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -13,6 +13,9 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
+  AlarmTopic:
+    Type: String
+    Description: The ARN of the SNS topic to send all the cloudwatch alarms to
 
 Resources:
   Role:


### PR DESCRIPTION
## What does this change?
I thought it might be a good idea to just add some alarms to our lambda, we might want to be alerted to any missing data on the night. 
