### PR TITLE
Get notification API key from a stack parameter

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -13,6 +13,9 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
+  NotificationApiKey:
+    Description: A key sent in the Authorization header of requests made to the N10N mobile notifications server
+    Type: String
 
 Resources:
   Role:
@@ -61,6 +64,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          NOTIFICATION_API_KEY: !Ref NotificationApiKey
       FunctionName: !Sub us-election-2020-notification-lambda-${Stage}
       Handler: notification-lambda.handler
       MemorySize: 384

--- a/notification-lambda.js
+++ b/notification-lambda.js
@@ -49,7 +49,7 @@ function postNotificationData(notificationData) {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            "Authorization": "Bearer xxx"
+            "Authorization": "Bearer " + process.env.NOTIFICATION_API_KEY
             //"Content-Length": Buffer.byteLength(notificationData)
         }
     }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We don't want to be hard-coding this API key. This change allows us to provide it as a stack parameter instead.