### PR TITLE
Disable production schedule

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -24,11 +24,13 @@ Mappings:
   StageVariables:
     CODE:
       AlarmActionsEnabled: FALSE
+      ScheduleStatus: ENABLED
       NotificationsEndpoint: "notification.notifications.code.dev-guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/max/"
       SendingEnabled: "true"
     PROD:
       AlarmActionsEnabled: FALSE
+      ScheduleStatus: DISABLED
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"
       SendingEnabled: "false"
@@ -103,6 +105,7 @@ Resources:
   EventRule:
     Type: AWS::Events::Rule
     Properties:
+      State: !FindInMap [StageVariables, !Ref Stage, ScheduleStatus]
       ScheduleExpression: rate(2 minutes)
       Targets:
         - Id: !Sub NotificationLambda${Stage}Target


### PR DESCRIPTION
There is currently no production data, which causes the lambda to throw an error. Let's disable the schedule (for production) until the production data is in place.

I've left the `CODE` schedule enabled for testing purposes.