### PR TITLE
Enable schedule in production

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -30,7 +30,7 @@ Mappings:
       SendingEnabled: "true"
     PROD:
       AlarmActionsEnabled: TRUE
-      ScheduleStatus: DISABLED
+      ScheduleStatus: ENABLED
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"
       SendingEnabled: "false"


### PR DESCRIPTION
Once the production data is in place, we can merge this PR.

Note that notifications will not actually be sent until https://github.com/guardian/us-election-2020-notification-lambda/pull/11 is also merged.