### PR TITLE
Read notification api key from an SSM parameter

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -74,7 +74,7 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource: !Sub
-                - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Path}
+                - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${Path}
                 - Path: !FindInMap [StageVariables, !Ref Stage, NotificationsApiKeyPath]
 
   Function:

--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -72,7 +72,7 @@ Resources:
             Statement:
               Effect: Allow
               Action:
-                - ssm:GetParametersByPath
+                - ssm:GetParameter
               Resource: !Sub
                 - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Path}
                 - Path: !FindInMap [StageVariables, !Ref Stage, NotificationsApiKeyPath]

--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -16,19 +16,18 @@ Parameters:
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
-  NotificationApiKey:
-    Description: A key sent in the Authorization header of requests made to the N10N mobile notifications server
-    Type: String
 
 Mappings:
   StageVariables:
     CODE:
       AlarmActionsEnabled: FALSE
+      NotificationsApiKeyPath: "/notifications/CODE/mobile-notifications/notifications.api.secretKeys.2"
       NotificationsEndpoint: "notification.notifications.code.dev-guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/max/"
       SendingEnabled: "true"
     PROD:
       AlarmActionsEnabled: FALSE
+      NotificationsApiKeyPath: "/notifications/PROD/mobile-notifications/notifications.api.secretKeys.4"
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"
       SendingEnabled: "false"
@@ -68,6 +67,15 @@ Resources:
               - Action:  s3:ListBucket
                 Effect: Allow
                 Resource: arn:aws:s3:::gdn-cdn
+        - PolicyName: ssm
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource: !Sub
+                - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Path}
+                - Path: !FindInMap [StageVariables, !Ref Stage, NotificationsApiKeyPath]
 
   Function:
     Type: AWS::Lambda::Function
@@ -81,7 +89,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
-          NotificationApiKey: !Ref NotificationApiKey
+          NotificationsApiKeyPath: !FindInMap [StageVariables, !Ref Stage, NotificationsApiKeyPath]
           SendingEnabled: !FindInMap [StageVariables, !Ref Stage, SendingEnabled]
           NotificationsEndpoint: !FindInMap [StageVariables, !Ref Stage, NotificationsEndpoint]
           ElectionsDataDirectory: !FindInMap [StageVariables, !Ref Stage, ElectionsDataDirectory]

--- a/notification-lambda.js
+++ b/notification-lambda.js
@@ -1,7 +1,6 @@
 // dependencies
 const AWS = require('aws-sdk');
 const https = require('https');
-const util = require('util');
 
 // get reference to S3 client
 const s3 = new AWS.S3();
@@ -47,12 +46,18 @@ async function getNotificationData(lastUpdatedTimestamp) {
     })
 }
 
-const getParam = util.promisify(parameterStore.getParameter);
+const getParam = param => new Promise((resolve, reject) =>
+    parameterStore.getParameter({ Name: param }, (err, data) => {
+        if (err) {
+            reject(err)
+        } else {
+            resolve(data)
+        }
+    })
+);
 
 async function postNotificationData(notificationData) {
-    const apiKey = await getParam({
-        Name: process.env.NotificationsApiKeyPath
-    });
+    const apiKey = await getParam(process.env.NotificationsApiKeyPath);
 
     const requestParams = {
         host: notificationsEndpoint,

--- a/notification-lambda.js
+++ b/notification-lambda.js
@@ -47,11 +47,11 @@ async function getNotificationData(lastUpdatedTimestamp) {
 }
 
 const getParam = param => new Promise((resolve, reject) =>
-    parameterStore.getParameter({ Name: param }, (err, data) => {
+    parameterStore.getParameter({ Name: param, WithDecryption: true }, (err, data) => {
         if (err) {
             reject(err)
         } else {
-            resolve(data)
+            resolve(data.Parameter.Value)
         }
     })
 );


### PR DESCRIPTION
## What does this change?
Pass in the notification api key values, using their SSM names instead of their values for security.
