### PR TITLE
Set sendingEnabled to false

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -32,7 +32,7 @@ Mappings:
       NotificationsApiKeyPath: "/notifications/PROD/mobile-notifications/notifications.api.secretKeys.4"
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"
-      SendingEnabled: "true"
+      SendingEnabled: "false"
 
 Resources:
   Role:


### PR DESCRIPTION
## What does this change?
This sets the sendingEnabled field to be false in the cloudformation, this will turn off the ability to send election notifications.