### PR TITLE
Revert "Set sendingEnabled to false"

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -32,7 +32,7 @@ Mappings:
       NotificationsApiKeyPath: "/notifications/PROD/mobile-notifications/notifications.api.secretKeys.4"
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"
-      SendingEnabled: "false"
+      SendingEnabled: "true"
 
 Resources:
   Role:


### PR DESCRIPTION
Reverts guardian/us-election-2020-notification-lambda#20

This sets the sendingEnabled flag to be True, which means notifications can resume sending