### PR TITLE
Disable the schedule

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -28,7 +28,7 @@ Mappings:
       SendingEnabled: "true"
     PROD:
       AlarmActionsEnabled: TRUE
-      ScheduleStatus: ENABLED
+      ScheduleStatus: DISABLED
       NotificationsApiKeyPath: "/notifications/PROD/mobile-notifications/notifications.api.secretKeys.4"
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"


### PR DESCRIPTION
## What does this change?
Disable the schedule so we can run the lambda manually, for US Election results we need editorial approval first before sending a notification
