### PR TITLE
Revert "Disable the schedule"

### DIFF
--- a/notification-lambda-cfn.yaml
+++ b/notification-lambda-cfn.yaml
@@ -28,7 +28,7 @@ Mappings:
       SendingEnabled: "true"
     PROD:
       AlarmActionsEnabled: TRUE
-      ScheduleStatus: DISABLED
+      ScheduleStatus: ENABLED
       NotificationsApiKeyPath: "/notifications/PROD/mobile-notifications/notifications.api.secretKeys.4"
       NotificationsEndpoint: "notification.notifications.guardianapis.com"
       ElectionsDataDirectory: "2020/11/us-general-election-data/prod/"


### PR DESCRIPTION
Reverts guardian/us-election-2020-notification-lambda#22

Enables the scheduling of the notifcation again, so we don't have to manually update the lambda